### PR TITLE
Fix README instructions for Excel file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **进行此步骤之前请先确保拥有 python 环境并安装依赖**
 
-1. 按照模板 `scrips/example.xlsx` 填写，制作歌单内容
+1. 参考 `scripts/example.xlsx` 填写，并将文件保存为 `music.xlsx`
 2. 运行 `python3 scripts/converter.py` 生成歌单文件
 
 ### 修改配置文件

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -1,7 +1,10 @@
 import json
 import pandas as pd
 
-song_df = pd.read_excel('./muisc.xlsx')
+# Read the filled Excel sheet. The file name was misspelled as
+# ``muisc.xlsx`` originally which caused a FileNotFoundError.  The
+# correct file name is ``music.xlsx``.
+song_df = pd.read_excel('./music.xlsx')
 song_df = song_df.where(pd.notnull(song_df), None)
 song_list = []
 


### PR DESCRIPTION
## Summary
- fix README to mention using `scripts/example.xlsx` and saving as `music.xlsx`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845117c45308320a6c551125c446655