### PR TITLE
Enhance song search tags

### DIFF
--- a/components/SongDetail.component.jsx
+++ b/components/SongDetail.component.jsx
@@ -2,10 +2,23 @@ import styles from "../styles/Home.module.css";
 
 import { Button } from "react-bootstrap";
 
+const splitValueToTags = (value) => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .toString()
+    .split(/[、,，/\\;；]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
 export default function SongDetail({
   filteredSongList,
   handleClickToCopy,
-  showBiliPlayer
+  showBiliPlayer,
+  onTagAdd,
 }) {
   if (filteredSongList.length == 0) {
     return (
@@ -16,6 +29,30 @@ export default function SongDetail({
       </tr>
     );
   }
+  const handleTagClick = (event, tagValue) => {
+    event.stopPropagation();
+    if (tagValue && onTagAdd) {
+      onTagAdd(tagValue);
+    }
+  };
+
+  const renderTagCell = (value) => {
+    const tags = splitValueToTags(value);
+    if (tags.length === 0) {
+      return <span>{value}</span>;
+    }
+
+    return tags.map((tag, index) => (
+      <span
+        key={`${tag}-${index}`}
+        className={styles.inlineTagPill}
+        onClick={(event) => handleTagClick(event, tag)}
+      >
+        {tag}
+      </span>
+    ));
+  };
+
   return filteredSongList.map((song) => (
     <tr
       className={
@@ -86,9 +123,9 @@ export default function SongDetail({
           <div></div>
         )}
       </td>
-      <td className={styles.noWrapForce}>{song.artist}</td>
-      <td className={styles.noWrapForce}>{song.language}</td>
-      <td className={styles.noWrapForce}>{song.remarks}</td>
+      <td className={styles.tagCell}>{renderTagCell(song.artist)}</td>
+      <td className={styles.tagCell}>{renderTagCell(song.language)}</td>
+      <td className={styles.tagCell}>{renderTagCell(song.remarks)}</td>
     </tr>
   ));
 }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -111,9 +111,84 @@
   cursor: url("/assets/cursor/text.png"), text;
 }
 
-.filters:focus {
+.filters:focus-within {
   background-color: rgba(255, 255, 255, 0.9);
   box-shadow: none;
+}
+
+.searchTagInput {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.75rem;
+}
+
+.searchTagInput:focus-within {
+  background-color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.searchTagInputField {
+  flex: 1;
+  min-width: 6rem;
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 0.25rem 0;
+  color: inherit;
+}
+
+.searchTagInputField::placeholder {
+  color: rgba(29, 12, 38, 0.6);
+}
+
+.searchTagPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background-color: rgba(254, 226, 231, 0.6);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.85rem;
+  line-height: 1.1;
+  color: #1d0c26;
+}
+
+.searchTagRemove {
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  line-height: 1;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.searchTagRemove:focus {
+  outline: none;
+}
+
+.tagCell {
+  max-width: 12rem;
+  white-space: normal;
+}
+
+.inlineTagPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  margin-right: 0.35rem;
+  margin-bottom: 0.35rem;
+  border-radius: 999px;
+  background-color: rgba(254, 226, 231, 0.6);
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #1d0c26;
+}
+
+.inlineTagPill:hover {
+  background-color: rgba(254, 226, 231, 0.9);
 }
 
 .customRandomButton {


### PR DESCRIPTION
## Summary
- add chip-based search input that stores selected filters as removable tags
- allow clicking artist, language, and remark labels to add them to the active search tags
- update styling to support the new tag UI in the search box and song table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4a91e53e88320993018354cddf922