### PR TITLE
Handle missing mobile custom buttons

### DIFF
--- a/components/banner/BannerMobile.component.jsx
+++ b/components/banner/BannerMobile.component.jsx
@@ -12,7 +12,7 @@ export default function BannerMobile({}) {
       {config.BannerContent.map((cnt) => {
         return <p className={styles.introParagraph} key={cnt}>{cnt}</p>;
       })}
-      {config.CustomButtons.map((btn) => {
+      {(config.CustomButtons || []).map((btn) => {
         return (
           <BannerButton
             link={btn.link}


### PR DESCRIPTION
## Summary
- prevent the mobile intro banner from crashing when CustomButtons is undefined

## Testing
- npm run lint (fails: next not found in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fc9d5f2808320afd10c7b69ae8c36)